### PR TITLE
Fix empty array encoding

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	newLine  = []byte{'\r', '\n'}
-	nilBulk  = []byte{'$', '-', '1', '\r', '\n'}
-	nilArray = []byte{'*', '-', '1', '\r', '\n'}
+	newLine    = []byte{'\r', '\n'}
+	nilBulk    = []byte{'$', '-', '1', '\r', '\n'}
+	emptyArray = []byte{'*', '0', '\r', '\n'}
 )
 
 func intToString(val int64) string {
@@ -87,7 +87,7 @@ func SendBulks(w *bufio.Writer, vals [][]byte) error {
 func sendBulks(w *bufio.Writer, vals [][]byte) error {
 	var e error
 	if vals == nil {
-		_, e = w.Write(nilArray)
+		_, e = w.Write(emptyArray)
 		e = w.Flush()
 		return e
 	}
@@ -109,7 +109,7 @@ func sendBulks(w *bufio.Writer, vals [][]byte) error {
 func SendObjects(w *bufio.Writer, vals []interface{}) error {
 	var e error
 	if vals == nil {
-		_, e = w.Write(nilArray)
+		_, e = w.Write(emptyArray)
 		e = w.Flush()
 		return e
 	}

--- a/writer.go
+++ b/writer.go
@@ -78,7 +78,7 @@ func (w *Writer) WriteError(s string) error {
 
 func (w *Writer) WriteObjects(objs ...interface{}) error {
 	if objs == nil {
-		_, err := w.Write(nilArray)
+		_, err := w.Write(emptyArray)
 		return err
 	}
 
@@ -125,7 +125,7 @@ func (w *Writer) WriteObjects(objs ...interface{}) error {
 
 func (w *Writer) WriteBulks(bulks ...[]byte) error {
 	if bulks == nil {
-		_, err := w.Write(nilArray)
+		_, err := w.Write(emptyArray)
 		return err
 	}
 
@@ -144,7 +144,7 @@ func (w *Writer) WriteBulks(bulks ...[]byte) error {
 
 func (w *Writer) WriteBulkStrings(bulks []string) error {
 	if bulks == nil {
-		_, err := w.Write(nilArray)
+		_, err := w.Write(emptyArray)
 		return err
 	}
 


### PR DESCRIPTION
The Redis protocol specification[1] defines an empty array as the
sequence `*0\r\n`. The previous value, `*-1\r\n` is what Redis calls the
"Null Array" which is used in some special cases, for example when a
`BLPOP` times out.

The variable is also renamed for consistency with the Redis conventions.

[1] https://redis.io/topics/protocol#resp-arrays